### PR TITLE
Draft: GoTo imports back and forth

### DIFF
--- a/Support/Indexed Reference List - Imports.tmPreferences
+++ b/Support/Indexed Reference List - Imports.tmPreferences
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>
+        source.qml meta.import.qml meta.path
+    </string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedReferenceList</key>
+        <string>1</string>
+    </dict>
+</dict>
+</plist>

--- a/Support/Indexed Symbol List - Imports.tmPreferences
+++ b/Support/Indexed Symbol List - Imports.tmPreferences
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.qmldir meta.module.qmldir meta.path</string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedSymbolList</key>
+        <string>1</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Currently failing QA because user must manually select the whole import
path if it contains more than one component (separated by dots). An
alternative to only index the last path component is quite unintuitive.

Should be implemented as a contextual command (the one that is available only in certain context/scope).