### PR TITLE
syntax: Copy/vendor some utilities rules from the inherited JavaScript package

### DIFF
--- a/Support/QML.sublime-syntax
+++ b/Support/QML.sublime-syntax
@@ -66,6 +66,15 @@ contexts:
     - match: (?=\s*$)
       pop: true
 
+  immediately-pop:
+    - match: ''
+      pop: 1
+
+  immediately-pop-2:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 2
+
   pragma-statement:
     - match: \b(pragma)\s+(Singleton)\b
       scope: meta.pragma.qml

--- a/Support/tests/syntax_test_QML.qml
+++ b/Support/tests/syntax_test_QML.qml
@@ -699,6 +699,19 @@ Expressions {
 //      ^^^^ support.class.builtin.js
 //          ^ punctuation.accessor.js
 //           ^^^ support.function.builtin.js
+        const y = k * (x + b);
+//      ^^^^^ keyword.declaration.js
+//            ^ meta.binding.name.js variable.other.readwrite.js
+//              ^ keyword.operator.assignment.js
+//                ^ variable.other.readwrite.js
+//                  ^ keyword.operator.arithmetic.js
+//                    ^^^^^^^ meta.group.js
+//                    ^ punctuation.section.group.begin.js
+//                     ^ variable.other.readwrite.js
+//                       ^ keyword.operator.arithmetic.js
+//                         ^ variable.other.readwrite.js
+//                          ^ punctuation.section.group.end.js
+//                           ^ punctuation.terminator.statement.js
         window
 //      ^^^^^^ - support.type
         XMLHttpRequest


### PR DESCRIPTION
immediately-pop-2 does not exist in SublimeText build 4148 anymore.

![image](https://user-images.githubusercontent.com/6737986/225319753-f1727b98-072f-4f47-97fe-6a6541fce6d2.png)