### PR TITLE
Syntax: Add support for `as` type hint operator in QML/JS expressions

### DIFF
--- a/Support/QML.sublime-syntax
+++ b/Support/QML.sublime-syntax
@@ -671,6 +671,20 @@ contexts:
 
     - include: else-pop-at-eol
 
+  # Copied from JavaScript syntax, added binary-operators-qml
+  expression-end:
+    - include: postfix-operators
+    - include: binary-operators
+    - include: binary-operators-qml
+    - include: ternary-operator
+
+    - include: left-expression-end
+
+  binary-operators-qml:
+    - match: as{{identifier_break}}
+      scope: keyword.operator.qml
+      push: expression-begin
+
   try-value-object:
     - match: (?={{identifier_title}})
       set:

--- a/Support/tests/syntax_test_QML.qml
+++ b/Support/tests/syntax_test_QML.qml
@@ -729,6 +729,24 @@ Expressions {
         XMLHttpRequest
 //      ^^^^^^^^^^^^^^ support.class.dom.js
     }
+    property real foox: (foo as Item).x
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.binding.property
+//                      ^ punctuation.section
+//                       ^^^ variable.other
+//                           ^^ keyword.operator.qml
+//                              ^^^^ support.class.builtin.qml
+//                                  ^ punctuation.section
+//                                   ^ punctuation.accessor.js
+    function support_qmljs() {
+        abc = def as X.Yz;
+//          ^ keyword.operator.assignment.js
+//            ^^^ variable.other.readwrite.js
+//                ^^ keyword.operator.qml
+//                   ^ support.class.js
+//                    ^ punctuation.accessor.js
+//                     ^^ meta.property.object.js
+//                       ^ punctuation.terminator.statement.js
+    }
     function support_qtqml() {
         Component.Ready
 //                ^^^^^ support.constant.builtin.qml


### PR DESCRIPTION
Fixes #17